### PR TITLE
[QSP-2] Unlocked Pragma

### DIFF
--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -84,7 +84,7 @@
     // Configure your compilers
     compilers: {
       solc: {
-        version: "0.8.6",    // Fetch exact version from solc-bin (default: truffle's version)
+        version: "0.8.4",    // Fetch exact version from solc-bin (default: truffle's version)
         // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
         // settings: {          // See the solidity docs for advice about optimization and evmVersion
         //  optimizer: {


### PR DESCRIPTION
Every Solidity file specifies in the header a version number of the format `pragma solidity (^)0.8.*`. In the case of parcels.sol, the directive is `pragma solidity ^0.8.4`. The caret (^) before the version number implies an unlocked pragma, meaning that the compiler will use the specified version **and above** , hence the term "unlocked".

The caret (^) before the version number implies an unlocked pragma, meaning that the compiler will use the specified version , hence the term "unlocked".

**Recommendation by QSP**: For consistency and to prevent unexpected behavior in the future, we recommend removing the caret to lock parcels.sol onto a specific Solidity version.

Status: **Resolved**