### PR TITLE
[QSP-3] Clarification over user `creator`

### DIFF
--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -113,8 +113,9 @@ contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
     }
 
     /**
-     * @notice see @ERC721._burn();
-     * @dev We purposely only allow the contract owner to burn. This is to relate to the real-world where one cannot destroy land.
+     * @notice Burn a parcel if caller is contract owner and parcel is owned by caller.
+     * @dev Only the contract owner can call; We purposely only allow the contract owner to burn. NFT owners cannot destroy land.
+     * @dev see @ERC721._burn();
      * @param _tokenId a token Id
      */
     function burn(uint256 _tokenId) public onlyOwner {
@@ -204,6 +205,7 @@ contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
 }
 
 contract Parcel is ParcelERC721Storage {
+    /// @dev creator of the smart contract.
     address internal creator;
 
     constructor() {
@@ -211,7 +213,9 @@ contract Parcel is ParcelERC721Storage {
     }
 
     /**
-     * @dev takeOwnership() let the original contract creator to take over the contract.
+     * @notice take ownership of the smart contract. Each parcels won't change owner.
+     * @dev Only the creator can call this function. It lets the original contract creator take over the contract.
+     * This allows the original contract creator to pass ownership to another worry-free that the other individual might rebel and never give ownership back
      */
     function takeOwnership() external {
         require(_msgSender() == creator);

--- a/docs/parcels.sol.md
+++ b/docs/parcels.sol.md
@@ -11,6 +11,7 @@
 The contract replicates the behaviors of [the previous Cryptovoxels contract](https://etherscan.io/token/0x79986af15539de2db9a5086382daeda917a9cf0c).
 
 - Only the contract owner should be able to mint or burn a parcel.
+- The contract creator should always be able to take ownership of the contract if the current contract owner is not him/her.
 - Users should be able to be given a parcel and transfer it just like any ERC721 NFT.
 - Users should be able to approve other addresses to use their NFT just like any ERC721 NFT (setApprovalForAll(), approve())
 - Parcels should have both an owner and a consumer (e.g. Owner and Renter)
@@ -34,7 +35,9 @@ See [EIP-4400 on Ethereum](https://eips.ethereum.org/EIPS/eip-4400) for more inf
 ### takeOwnership
 ```js
     /**
-     * @dev takeOwnership() let the original contract creator to take over the contract.
+     * @notice take ownership of the smart contract. Each parcels won't change owner.
+     * @dev Only the creator can call this function. It lets the original contract creator take over the contract.
+     * This allows the original contract creator to pass ownership to another worry-free that the other individual might rebel and never give ownership back
      */
     function takeOwnership() external {
         require(_msgSender()== creator);

--- a/docs/parcels.sol.md
+++ b/docs/parcels.sol.md
@@ -13,6 +13,7 @@ The contract replicates the behaviors of [the previous Cryptovoxels contract](ht
 Permissions:
 - Only the contract owner (set by Ownable.sol) should be able to mint or burn an NFT (a parcel).
 - Contract owner (set by ownable.sol) can transfer ownership to anyone.
+- If contract creator has transferred ownership to a new owner, the contract creator shouldn't be able to mint / burn NFTs.
 - The contract creator should always be able to take ownership of the contract if the current contract owner is not him/her.
 - The contract owner should not be able to burn NFTs he/she does not own.
 Functionalities:

--- a/docs/parcels.sol.md
+++ b/docs/parcels.sol.md
@@ -10,8 +10,12 @@
 
 The contract replicates the behaviors of [the previous Cryptovoxels contract](https://etherscan.io/token/0x79986af15539de2db9a5086382daeda917a9cf0c).
 
-- Only the contract owner should be able to mint or burn a parcel.
+Permissions:
+- Only the contract owner (set by Ownable.sol) should be able to mint or burn an NFT (a parcel).
+- Contract owner (set by ownable.sol) can transfer ownership to anyone.
 - The contract creator should always be able to take ownership of the contract if the current contract owner is not him/her.
+- The contract owner should not be able to burn NFTs he/she does not own.
+Functionalities:
 - Users should be able to be given a parcel and transfer it just like any ERC721 NFT.
 - Users should be able to approve other addresses to use their NFT just like any ERC721 NFT (setApprovalForAll(), approve())
 - Parcels should have both an owner and a consumer (e.g. Owner and Renter)

--- a/docs/parcels.sol.md
+++ b/docs/parcels.sol.md
@@ -54,7 +54,7 @@ See [EIP-4400 on Ethereum](https://eips.ethereum.org/EIPS/eip-4400) for more inf
 ```
 Note: This function is present in the old parcel contract and brought back.
 At construction, the `address creator` variable is set as the original contract creator. Since the contract is `Ownable`, the owner of the contract can give ownership to someone else.
-However, if the new owner is unwilling to cooperate, the original contract creator loses control over the contract.
+However, if the new owner is unwilling to cooperate with the creator, the original contract creator loses control over the contract.
 This function is to guarantee the original contract creator can take back ownership of the contract with `takeOwnership()`.
 
 This function does not affect NFT ownerships.

--- a/docs/parcels.sol.md
+++ b/docs/parcels.sol.md
@@ -50,7 +50,10 @@ See [EIP-4400 on Ethereum](https://eips.ethereum.org/EIPS/eip-4400) for more inf
 ```
 Note: This function is present in the old parcel contract and brought back.
 At construction, the `address creator` variable is set as the original contract creator. Since the contract is `Ownable`, the owner of the contract can give ownership to someone else.
-However, if new owner is unwilling to cooperate, the original contract creator can take back ownership of the contract with `takeOwnership()`.
+However, if the new owner is unwilling to cooperate, the original contract creator loses control over the contract.
+This function is to guarantee the original contract creator can take back ownership of the contract with `takeOwnership()`.
+
+This function does not affect NFT ownerships.
 
 ### transferOwnership override
 ```js


### PR DESCRIPTION
**Issue description:** The `creator` of a `Parcel` can take back ownership of a `Parcel` they have created, allowing the `creator` to mint and burn NFTs. This lack of separation of responsibility creates a single point of failure. Additionally, there is no documentation on what safety controls will be in place for the `creator` . 

**Resolution**:
I understand the main issue here is misunderstanding over what the creator variable is and what it can do.
Therefore I've updated the documentation and the comments to clarify the desired behaviors.

The creator = contract creator
The owner = contract owner set by Ownable.sol
The creator is the first owner and can give contract ownership to `0xAbc`. Now `0xAbc` can mint and burn NFTs and `Creator` cannot. But if `0xAbc` is unwilling to cooperate with the creator, the creator can call `takeOwnership` to take ownership of the contract back.

⚠️ This means the owner can lose ownership at anytime with no accountability. There are no off-chain processes to capture this.

NFT owners are intentionally not able to mint or burn NFTs.

Status: Resolved.