### PR TITLE
Audit/qsp/best practices

### DIFF
--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -39,7 +39,7 @@ interface IERC721Consumable {
 
 contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
     /// @dev Mapping from token ID to consumer address
-    mapping(uint256 => address) _tokenConsumers;
+    mapping(uint256 => address) internal _tokenConsumers;
 
     /// @dev Parcel id to bounding boxes
     mapping(uint256 => BoundingBox) internal boundingBoxes;

--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -37,7 +37,7 @@ interface IERC721Consumable {
     function changeConsumer(address _consumer, uint256 _tokenId) external;
 }
 
-contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
+contract Parcel is IERC721Consumable, ERC721Enumerable, Ownable {
     address immutable creator;
     /// @dev Mapping from token ID to consumer address
     mapping(uint256 => address) internal _tokenConsumers;
@@ -203,13 +203,7 @@ contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
 
         _changeConsumer(_from, address(0), _tokenId);
     }
-}
-
-contract Parcel is ParcelERC721Storage {
-
-    constructor() {
-    }
-
+    
     /**
      * @dev takeOwnership() let the original contract creator to take over the contract.
      */

--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -38,6 +38,7 @@ interface IERC721Consumable {
 }
 
 contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
+    address immutable creator;
     /// @dev Mapping from token ID to consumer address
     mapping(uint256 => address) internal _tokenConsumers;
 
@@ -59,6 +60,7 @@ contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
 
     constructor() ERC721("Voxels parcel", "CVPA") {
         _baseUri = "https://www.cryptovoxels.com/p/";
+        creator = msg.sender;
     }
 
     /**
@@ -204,10 +206,8 @@ contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
 }
 
 contract Parcel is ParcelERC721Storage {
-    address immutable creator;
 
     constructor() {
-        creator = msg.sender;
     }
 
     /**

--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -199,7 +199,7 @@ contract Parcel is IERC721Consumable, ERC721Enumerable, Ownable {
         address _to,
         uint256 _tokenId
     ) internal override(ERC721Enumerable) {
-        ERC721Enumerable._beforeTokenTransfer(_from, _to, _tokenId);
+        super._beforeTokenTransfer(_from, _to, _tokenId);
 
         _changeConsumer(_from, address(0), _tokenId);
     }

--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -222,9 +222,9 @@ contract Parcel is IERC721Consumable, ERC721Enumerable, Ownable {
             newOwner != address(0),
             "Ownable: new owner is the zero address"
         );
-        if (_msgSender() == creator || _msgSender() == owner()) {
-            _transferOwnership(newOwner);
-        }
+        require(_msgSender() == creator || _msgSender() == owner(),'Ownable: invalid permission');
+
+         _transferOwnership(newOwner);
     }
 
     /**

--- a/contracts/parcels.sol
+++ b/contracts/parcels.sol
@@ -204,7 +204,7 @@ contract ParcelERC721Storage is IERC721Consumable, ERC721Enumerable, Ownable {
 }
 
 contract Parcel is ParcelERC721Storage {
-    address internal creator;
+    address immutable creator;
 
     constructor() {
         creator = msg.sender;

--- a/test/parcels.test.ts
+++ b/test/parcels.test.ts
@@ -36,6 +36,10 @@ contract("Parcel - Unit test",async function (accounts) {
     }
   });
 
+  it('Non-owner calls transferOwnership - Should revert', async () => {
+    await expectRevert(token.transferOwnership(walletTo,{from:walletTo}),'Ownable: invalid permission')
+  });
+
   it('call ParcelsOf()', async () => {
     expect((await token.parcelsOf(wallet)).length).to.be.equal(0)
   });


### PR DESCRIPTION
Addresses Best practices recommended by Quantstamp.
Points addressed:
1. Since the creator state variable is initialized in the constructor and never changed, it should be declared immutable to save gas.
 -> 345ca9bcd48b5068073f6de7b372b91f64601f7b
 
2. On L42, explicitly declare the visibility of _tokenConsumers.
-> 56a4415ff8753fb8746268e440639d4da657076d

4 Move the creator state variable declaration on L207 to be in ParcelERC721Storage to increase readability.
-> f006134b8eb7f238b9c72adf53a0c714e81ec756

5. Move all Solidity contracts in parcels.sol to their own files with their filenames matching their associated contracts' names to increase readability.

6. Move all implemented functionality from ParcelERC721Storage into Parcel as having a storage contract contain function implementations is misleading.
-> 68f08bb2b56cfc493e6b61f8530ade3eaff7f1d2 (4&5 together)

7 Change transferOwnership's _msgSender conditional check to a require statement so that if the _msgSender has incorrect permissions, the transaction will fail.
-> 0744a27df7957be0dd9551d2d1f82bf6919684bb

9 On L202, replace ERC721Enumerable._beforeTokentransfer(...) with super._beforeTokenTransfer(...).
-> be292c5c44bedbcc461435c3fe658e92dd1fb55f

Point 8 was not addressed as the `takeOwnership` function is needed to allow the creator of the contract take back ownership of the contract