### PR TITLE
Add supportInterface tests.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,3 +34,6 @@ run `truffle develop` follow by `test`
 Edit your local network in truffle-config.js under 'development'.
 
 run `truffle test`
+
+Screenshot of test results:
+![image](https://user-images.githubusercontent.com/38708022/167714141-6dd5c28c-68e8-4d2c-8796-91fee8ce525b.png)

--- a/test/parcels.test.ts
+++ b/test/parcels.test.ts
@@ -26,7 +26,15 @@ contract("Parcel - Unit test",async function (accounts) {
     expect(await token.symbol()).to.equal('CVPA');
     expect(await token.name()).to.equal('Voxels parcel');
   });
-  
+
+  it('Contract support ERC721 interface', async () => {
+    expect(await token.supportsInterface('0x80ac58cd')).to.be.true
+  });
+
+  it('Contract does not support ERC1155 interface', async () => {
+    expect(await token.supportsInterface('0xd9b67a26')).to.be.false
+  });
+
   it('Owner calls transferOwnership', async () => {
     try{
       await token.transferOwnership(walletTo)
@@ -78,7 +86,7 @@ contract("Parcel - Unit test",async function (accounts) {
 })
 
 
- contract("Parcels - Integration tests",async function (accounts) {
+contract("Parcels - Integration tests",async function (accounts) {
 
   const [wallet,walletTo,walletThree] = accounts
   let token:ParcelInstance


### PR DESCRIPTION
PR adds 2 extra tests for the `supportInterface()` method.

Since an argument for this new parcel contract is "To make the contract a proper ERC721", it makes sense to test that it is indeed an ERC721.